### PR TITLE
set the correct path to the pidfile for redis source installs

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -29,6 +29,8 @@ port            = node['redis']['port']
 redis_user      = node['redis']['source']['user']
 redis_group     = node['redis']['source']['group']
 
+node.set_unless['redis']['pidfile'] = "/var/run/redis_#{port}.pid"
+
 Array(node['redis']['source']['pkgs']).each { |pkg| package pkg }
 
 remote_file "#{cache_dir}/#{tar_file}" do

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -6,7 +6,11 @@ daemonize <%= node['redis']['daemonize'] %>
 
 # When run as a daemon, Redis write a pid file in /var/run/redis.pid by default.
 # You can specify a custom pid file location here.
+<% if node['redis']['pidfile'] %>
+pidfile <%= node['redis']['pidfile'] %>
+<% else %>
 pidfile /var/run/redis.pid
+<% end %>
 
 # Accept connections on the specified port, default is 6379
 port <%= node['redis']['port'] %>


### PR DESCRIPTION
The redis source install expected a pidfile path like PIDFILE=/var/run/redis_${REDISPORT}.pid rather than PIDFILE=/var/run/redis.pid.
