### PR TITLE
Update Redis and fix PID path

### DIFF
--- a/attributes/source.rb
+++ b/attributes/source.rb
@@ -18,13 +18,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-default['redis']['source']['version'] = "2.4.8"
+default['redis']['source']['version'] = "2.4.16"
 default['redis']['source']['prefix']  = "/usr/local"
 
 default['redis']['source']['tar_url']   =
   "http://redis.googlecode.com/files/redis-#{node['redis']['source']['version']}.tar.gz"
-default['redis']['source']['tar_checksum']   =
-  "8166ca6ddea4bdb311510590a1ef94e3e32eed2fae44875a5b44fe72bda556f3"
+default['redis']['source']['tar_checksum']   = "31bb43e42f488300708086d42f88693b"
 
 default['redis']['source']['create_service']  = true
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email "christian.trabold@dkd.de"
 license          "All rights reserved"
 description      "Installs/Configures redis"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.3"
+version          "0.0.4"
 recipe            "redis", "Includes the package recipe by default."
 recipe            "redis::package", "Sets up a redis server."
 recipe            "redis::gem", "Installs redis gem for ruby development."

--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -6,7 +6,7 @@ daemonize <%= node['redis']['daemonize'] %>
 
 # When run as a daemon, Redis write a pid file in /var/run/redis.pid by default.
 # You can specify a custom pid file location here.
-pidfile /var/run/redis.pid
+pidfile /var/run/redis_<%= node['redis']['port'] %>.pid
 
 # Accept connections on the specified port, default is 6379
 port <%= node['redis']['port'] %>


### PR DESCRIPTION
I've updated the recipe to use Redis `2.4.16` and i've also updated the PID path (now `/var/run/redis_$port.pid`).
