### PR TITLE
[16] Fix installation of 2.6+ from source

### DIFF
--- a/templates/default/redis.conf.erb
+++ b/templates/default/redis.conf.erb
@@ -170,10 +170,12 @@ appendfsync always
 
 ############################### ADVANCED CONFIG ###############################
 
-# Glue small output buffers together in order to send small replies in a
+<% if node['redis']['source']['version'].to_f < 2.6; then %>
+<%= "# Glue small output buffers together in order to send small replies in a
 # single TCP packet. Uses a bit more CPU but most of the times it is a win
 # in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes
+glueoutputbuf yes" %>
+<% end %>
 
 # Use object sharing. Can save a lot of memory if you have many common
 # string in your dataset, but performs lookups against the shared objects


### PR DESCRIPTION
This fixes #16 

Here's the changelog:

https://raw.github.com/antirez/redis/2.6/00-RELEASENOTES

```
The following redis.conf and CONFIG GET / SET parameters changed:

    * hash-max-zipmap-entries, now replaced by hash-max-ziplist-entries
    * hash-max-zipmap-value, now replaced by hash-max-ziplist-value
    * glueoutputbuf option was now completely removed (was deprecated)
```
