### PR TITLE
Add init.d scripts & limits conf

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -24,3 +24,4 @@ default['redis']['daemonize']    = "yes"
 default['redis']['timeout']      = "300"
 default['redis']['loglevel']     = "notice"
 default['redis']['password']     = nil
+default['redis']['ulimit']       = 65536

--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -73,12 +73,12 @@ end
 end
 
 if node['redis']['source']['create_service']
-  execute "Install redis-server init.d script" do
-    command   <<-COMMAND
-      cp #{cache_dir}/#{tar_dir}/utils/redis_init_script /etc/init.d/redis
-    COMMAND
 
-    creates   "/etc/init.d/redis"
+  template "/etc/init.d/redis" do
+    source  "redis_init_script.erb"
+    owner   "root"
+    group   "root"
+    mode    "0755"
   end
 
   file "/etc/init.d/redis" do
@@ -87,23 +87,29 @@ if node['redis']['source']['create_service']
     mode    "0755"
   end
 
-  service "redis" do
-    supports  :status => false, :restart => false, :reload => false
-    action    :enable
-  end
-
   directory "/etc/redis" do
     owner   "root"
     group   "root"
     mode    "0755"
   end
 
-  template "/etc/redis/#{port}.conf" do
+  template "/etc/security/limits.d/redis.conf" do
+    source  "redis.conf.limits.erb"
+    owner   "root"
+    group   "root"
+    mode    "0644"
+  end
+
+  template "/etc/redis/redis.conf" do
     source  "redis.conf.erb"
     owner   "root"
     group   "root"
     mode    "0644"
-
-    notifies :restart, "service[redis]"
   end
+
+  service "redis" do
+    supports  :status => false, :restart => false, :reload => false
+    action    [:enable, :start]
+  end
+
 end

--- a/templates/default/redis.conf.limits.erb
+++ b/templates/default/redis.conf.limits.erb
@@ -1,0 +1,4 @@
+* soft nofile 65536
+* hard nofile 65536
+redis soft nofile 65536
+redis soft nofile 65536

--- a/templates/default/redis_init_script.erb
+++ b/templates/default/redis_init_script.erb
@@ -1,0 +1,41 @@
+# Simple Redis init.d script conceived to work on Linux systems
+# as it does use of the /proc filesystem.
+
+EXEC=/usr/local/bin/redis-server
+CLIEXEC=/usr/local/bin/redis-cli
+
+PIDFILE=/var/run/redis.pid
+CONF="/etc/redis/redis.conf"
+
+ulimit -n <%= node['redis']['ulimit'] %>
+
+case "$1" in
+    start)
+        if [ -f $PIDFILE ]
+        then
+                echo "$PIDFILE exists, process is already running or crashed"
+        else
+                echo "Starting Redis server..."
+                $EXEC $CONF
+        fi
+        ;;
+    stop)
+        if [ ! -f $PIDFILE ]
+        then
+                echo "$PIDFILE does not exist, process is not running"
+        else
+                PID=$(cat $PIDFILE)
+                echo "Stopping ..."
+                $CLIEXEC -p $REDISPORT shutdown
+                while [ -x /proc/${PID} ]
+                do
+                    echo "Waiting for Redis to shutdown ..."
+                    sleep 1
+                done
+                echo "Redis stopped"
+        fi
+        ;;
+    *)
+        echo "Please use start or stop as first argument"
+        ;;
+esac


### PR DESCRIPTION
If chef scripts kick init.d/redis, doesn't work ulimit.
So, add "ulimit -n" in init.d script
